### PR TITLE
[Suggestion] Damage Dropoff by Range

### DIFF
--- a/src/main/java/me/zombie_striker/qg/config/GunYML.java
+++ b/src/main/java/me/zombie_striker/qg/config/GunYML.java
@@ -60,6 +60,26 @@ public class GunYML extends ArmoryYML {
 		set(false, "swayMultiplier", multiplier);
 		return this;
 	}
+	
+	public GunYML setRangeStart(int rangeStart) {
+	    set(false, "rangeStart", rangeStart);
+	    return this;
+	}
+	
+	public GunYML setRangeEnd(int rangeEnd) {
+        set(false, "rangeEnd", rangeEnd);
+        return this;
+    }
+	
+	public GunYML setMinDamage(double minDamage) {
+        set(false, "minDamage", minDamage);
+        return this;
+    }
+	
+	public GunYML setMaxDamage(double maxDamage) {
+        set(false, "maxDamage", maxDamage);
+        return this;
+    }
 
 	public GunYML setHeadShotMultiplier(double multiplier) {
 		set(false, "headshotMultiplier", multiplier);

--- a/src/main/java/me/zombie_striker/qg/config/GunYMLLoader.java
+++ b/src/main/java/me/zombie_striker/qg/config/GunYMLLoader.java
@@ -293,8 +293,17 @@ public class GunYMLLoader {
 			g.setHasIronsights(f2.getBoolean("enableIronSights"));
 		if (f2.contains("maxbullets"))
 			g.setMaxBullets(f2.getInt("maxbullets"));
+		// deprecated
 		if (f2.contains("damage"))
 			g.setDamage(f2.getInt("damage"));
+		if(f2.contains("rangeStart"))
+		    g.setRangeStart(f2.getInt("rangeStart"));
+        if(f2.contains("rangeEnd"))
+            g.setRangeEnd(f2.getInt("rangeEnd"));
+        if(f2.contains("minDamage"))
+            g.setMinDamage(f2.getInt("minDamage"));
+        if(f2.contains("maxDamage"))
+            g.setMaxDamage(f2.getInt("maxDamage"));
 		if (f2.contains("durability"))
 			g.setDuribility(f2.getInt("durability"));
 		if (f2.contains("price"))

--- a/src/main/java/me/zombie_striker/qg/guns/Gun.java
+++ b/src/main/java/me/zombie_striker/qg/guns/Gun.java
@@ -36,6 +36,7 @@ public class Gun extends CustomBaseObject implements ArmoryBaseObject, Comparabl
 	private double acc;
 	private double swaymultiplier = 2;
 	private int maxbull;
+	@Deprecated
 	private float damage;
 	
 	/** These values control the damage a gun can deal at various ranges - replaces the "damage" value entirely */
@@ -103,7 +104,11 @@ public class Gun extends CustomBaseObject implements ArmoryBaseObject, Comparabl
 		this.acc = g.acc;
 		this.swaymultiplier = g.swaymultiplier;
 		this.maxbull = g.maxbull;
-		this.damage = g.damage;
+//		this.damage = g.damage;
+		this.minDamage = g.minDamage;
+		this.maxDamage = g.maxDamage;
+		this.rangeStart = g.rangeStart;
+		this.rangeEnd = g.rangeEnd;
 		this.durib = g.durib;
 		this.isAutomatic = g.isAutomatic;
 		this.supports18 = g.supports18;
@@ -132,7 +137,6 @@ public class Gun extends CustomBaseObject implements ArmoryBaseObject, Comparabl
 		this.customProjectile = g.customProjectile;
 		this.velocity = g.velocity;
 		this.recoil = g.recoil;
-
 	}
 
 	@Deprecated
@@ -198,6 +202,38 @@ public class Gun extends CustomBaseObject implements ArmoryBaseObject, Comparabl
 	public void setDamage(float damage) {
 		this.damage = damage;
 	}
+	
+	public float getMaxDamage() {
+        return maxDamage;
+    }
+	
+	public void setMaxDamage(float maxDamage) {
+        this.maxDamage = maxDamage;
+    }
+	
+	public float getMinDamage() {
+        return minDamage;
+    }
+	
+	public void setMinDamage(float minDamage) {
+        this.minDamage = minDamage;
+    }
+	
+	public int getRangeStart() {
+        return rangeStart;
+    }
+	
+	public int getRangeEnd() {
+        return rangeEnd;
+    }
+	
+	public void setRangeStart(int rangeStart) {
+        this.rangeStart = rangeStart;
+    }
+	
+	public void setRangeEnd(int rangeEnd) {
+        this.rangeEnd = rangeEnd;
+    }
 
 	public void setDuribility(int durib) {
 		this.durib = durib;
@@ -555,6 +591,21 @@ public class Gun extends CustomBaseObject implements ArmoryBaseObject, Comparabl
 	@Override
 	public String getSoundOnHit() {
 		return null;
+	}
+	
+	public double calculateDamage(double shooterAndTargetDistance) {
+	    // Fallback
+	    if(getMaxDamage() == 0 && getMinDamage() == 0) {
+	        return this.damage;
+	    }
+	    if(shooterAndTargetDistance <= getRangeStart()) {
+	        return this.getMaxDamage();
+	    }
+	    if(shooterAndTargetDistance >= getRangeEnd()) {
+	        return this.getMinDamage();
+	    }
+	    double dmgDropoffPerBlock = (getMaxDamage() - getMinDamage()) / (getRangeEnd() - getRangeStart());
+	    return getMaxDamage() - dmgDropoffPerBlock * (shooterAndTargetDistance-getRangeStart());
 	}
 
 	@SuppressWarnings("deprecation")

--- a/src/main/java/me/zombie_striker/qg/guns/Gun.java
+++ b/src/main/java/me/zombie_striker/qg/guns/Gun.java
@@ -37,6 +37,13 @@ public class Gun extends CustomBaseObject implements ArmoryBaseObject, Comparabl
 	private double swaymultiplier = 2;
 	private int maxbull;
 	private float damage;
+	
+	/** These values control the damage a gun can deal at various ranges - replaces the "damage" value entirely */
+    private int rangeStart;
+	private int rangeEnd;
+    private float minDamage;
+	private float maxDamage;
+	
 	private int durib = 1000;
 	private boolean isAutomatic;
 	boolean supports18 = false;

--- a/src/main/java/me/zombie_striker/qg/guns/utils/GunUtil.java
+++ b/src/main/java/me/zombie_striker/qg/guns/utils/GunUtil.java
@@ -195,7 +195,8 @@ public class GunUtil {
 						}
 					}
 
-					double damageMAX = damage * (bulletProtection ? 0.1 : 1)
+					double distance = p.getLocation().distance(hitTarget.getLocation());
+					double damageMAX = g.calculateDamage(distance) * (bulletProtection ? 0.1 : 1)
 							* ((headshot && !negateHeadshot) ? (QAMain.HeadshotOneHit ? 50 * g.getHeadshotMultiplier() : g.getHeadshotMultiplier())
 							: 1);
 


### PR DESCRIPTION
Hello ZombieStriker,
I was playing around with the QualityArmory plugin, and I think it's really fun, great job! :)
However I was wondering why weapons such as the 10mmpistol and the AK-47 have the same "damage" values. (rifle should deal more damage than a pistol - right?)
The default damage values are also pretty low in my opinion ... When damage = 2, you need to hit 10 shots (even at close range) to kill your target...

This is why I decided to try and add "ranged damage" configuration options, which applies the damage with considertation of the amount of blocks between shooter and target. I believe some FPS games use similar mechanisms in order to balance the power of their guns.

It works like this: If your target is very close (`rangeStart`), then `maxDamage` will be applied. If the target is very far away (`rangeEnd`), then `minDamage` is applied. Any distances in between will be calculated by the plugin (linear drop off from max to min damage).

Please note that I only changed the minimum amount of code to get it working, so this Pull Request may need some more work.

Best Regards