### PR TITLE
Updated Parties support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,10 @@
             <id>codemc-repo</id>
             <url>https://repo.codemc.org/repository/maven-public/</url>
         </repository>
+        <repository>
+            <id>alessiodp-repo</id>
+            <url>https://repo.alessiodp.com/releases/</url>
+        </repository>
 
         <repository>
             <id>everything</id>
@@ -158,7 +162,7 @@
         <dependency>
             <groupId>com.alessiodp.parties</groupId>
             <artifactId>parties-api</artifactId>
-            <version>2.6.14</version>
+            <version>3.0.0-rc.1</version>
         </dependency>
 
         <!-- PluginConstructorAPI -->

--- a/src/main/java/me/zombie_striker/qg/guns/utils/GunUtil.java
+++ b/src/main/java/me/zombie_striker/qg/guns/utils/GunUtil.java
@@ -3,6 +3,7 @@ package me.zombie_striker.qg.guns.utils;
 import com.alessiodp.parties.api.Parties;
 import com.alessiodp.parties.api.interfaces.PartiesAPI;
 import com.alessiodp.parties.api.interfaces.Party;
+import com.alessiodp.parties.api.interfaces.PartyPlayer;
 import me.zombie_striker.customitemmanager.CustomBaseObject;
 import me.zombie_striker.qg.QAMain;
 import me.zombie_striker.qg.ammo.Ammo;
@@ -137,9 +138,10 @@ public class GunUtil {
 							if (QAMain.hasParties && (!QAMain.friendlyFire)) {
 								try {
 									PartiesAPI api = Parties.getApi();
-									String partyName = api.getPartyPlayer(p.getUniqueId()).getPartyName();
-									if (!partyName.isEmpty() && partyName.equalsIgnoreCase(api.getPartyPlayer(e.getUniqueId()).getPartyName())) {
-										Party party = api.getParty(partyName);
+									PartyPlayer pp1 = api.getPartyPlayer(p.getUniqueId());
+									PartyPlayer pp2 = api.getPartyPlayer(e.getUniqueId());
+									if (pp1.getPartyId() != null && pp1.getPartyId().equals(pp2.getPartyId())) {
+										Party party = api.getParty(pp1.getPartyId());
 										if (party != null && party.isFriendlyFireProtected()) {
 											continue;
 										}


### PR DESCRIPTION
This PR will update Parties dependency to the `3.0.0-rc.1` version.

This change is required to handle null named Parties, now is used the UUID instead of String name.