### PR TITLE
Adding anti-cheat Matrix support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Matrix -->
+        <dependency>
+            <groupId>com.github.jiangdashao</groupId>
+            <artifactId>matrix-api-repo</artifactId>
+            <version>317d4635fd</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- WorldGuard API -->
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>

--- a/src/main/java/me/zombie_striker/qg/QAMain.java
+++ b/src/main/java/me/zombie_striker/qg/QAMain.java
@@ -27,6 +27,7 @@ import me.zombie_striker.qg.handlers.*;
 import me.zombie_striker.qg.guns.chargers.*;
 import me.zombie_striker.qg.guns.reloaders.PumpactionReloader;
 import me.zombie_striker.qg.guns.reloaders.SingleBulletReloader;
+import me.zombie_striker.qg.hooks.MatrixHook;
 import me.zombie_striker.qg.hooks.SpartanHook;
 import me.zombie_striker.qg.hooks.protection.ProtectionHandler;
 import me.zombie_striker.qg.listener.QAListener;
@@ -637,6 +638,10 @@ public class QAMain extends JavaPlugin {
 		if (Bukkit.getPluginManager().isPluginEnabled("Spartan")) {
 			Bukkit.getPluginManager().registerEvents(new SpartanHook(), this);
 			this.getLogger().info("Found Spartan AntiCheat. Loaded support");
+		}
+		if (Bukkit.getPluginManager().isPluginEnabled("Matrix")) {
+			Bukkit.getPluginManager().registerEvents(new MatrixHook(), this);
+			this.getLogger().info("Found Matrix AntiCheat. Loaded support");
 		}
 /*		if (Bukkit.getPluginManager().isPluginEnabled("Oraxen") && (boolean) a("hooks.oraxen", true)) {
 			Bukkit.getPluginManager().registerEvents(new OraxenHook(), this);

--- a/src/main/java/me/zombie_striker/qg/hooks/MatrixHook.java
+++ b/src/main/java/me/zombie_striker/qg/hooks/MatrixHook.java
@@ -1,0 +1,23 @@
+package me.zombie_striker.qg.hooks;
+
+import me.rerere.matrix.api.events.PlayerViolationEvent;
+import me.zombie_striker.qg.QAMain;
+import me.zombie_striker.qg.api.QualityArmory;
+import me.zombie_striker.qg.guns.Gun;
+import me.zombie_striker.qg.guns.utils.GunUtil;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class MatrixHook implements Listener {
+
+    @EventHandler
+    public void onFlag(PlayerViolationEvent event) {
+        Gun gun = QualityArmory.getGunInHand(event.getPlayer());
+        if (gun == null) return;
+
+        if (GunUtil.isDelay(gun,event.getPlayer())) {
+            event.setCancelled(true);
+            QAMain.DEBUG("Cancelled matrix violation because player is using gun.");
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -29,7 +29,7 @@ permissions:
       qualityarmory.craft: true
       qualityarmory.shop: true
       qualityarmory.usegun: true
-softdepend: [Vault, PlaceholderAPI, ChestShop, Parties, WorldGuard, ViaVersion, ViaRewind, LightAPI, Citizens, ProtocolLib, SunLight-Core, ItemBridge, Sentinel, Spartan, Towny, Residence]
+softdepend: [Vault, PlaceholderAPI, ChestShop, Parties, WorldGuard, ViaVersion, ViaRewind, LightAPI, Citizens, ProtocolLib, SunLight-Core, ItemBridge, Sentinel, Spartan, Towny, Residence, Matrix]
 authors:
   - Zombie_Striker
   - Lorenzo0111


### PR DESCRIPTION
Matrix is an increasingly popular anti-cheat and is used on many servers. When using a weapon, the Matrix falsely triggers this. I decided to fix this and add a connection to this anti-cheat to make using the plugin more convenient.

Thanks to [@treeDerevo](https://github.com/treeDerevo) for the idea to do this.