### PR TITLE
Quick workaround for pvp in WorldGuard regions

### DIFF
--- a/src/main/java/me/zombie_striker/qg/hooks/protection/implementation/WorldGuardHook.java
+++ b/src/main/java/me/zombie_striker/qg/hooks/protection/implementation/WorldGuardHook.java
@@ -26,7 +26,10 @@ public class WorldGuardHook implements ProtectionHook {
     @Override
     public boolean canPvp(@NotNull Location location) {
         for (IWrappedRegion k : worldGuard.getRegions(location)) {
-            WrappedState wrappedState = k.getFlag(pvp).orElse(WrappedState.ALLOW);
+            Object wrappedState = k.getFlag(pvp).orElse(WrappedState.ALLOW);
+            if(wrappedState.getClass().equals(Optional.class)) {
+                wrappedState = ((Optional<WrappedState>) wrappedState).orElse(WrappedState.ALLOW);
+            }
             if (wrappedState.equals(WrappedState.DENY)) return false;
         }
 


### PR DESCRIPTION
Hello! I really enjoy this plugin as it is extremely cool and flexible. But I started noticing pvp flag in WorldGuard does not work and fills my console with backtraces. It might be an issue in Wrapper library you are using, I don't know since I've never worked with it. But this issue is annoying and forces me to build pvp-gun areas with bedrock etc to not have a region there or enable pvp globally. So I made this workaround because `getFlag` seems to return double `Optional` if flag exists.
Also! It may also include explosion and block breaking flags, but I have block griefing disabled on my production server so can't tell (mention me if it is an issue)

Related (does not close until full fix) to #273