### PR TITLE
Fixed yaw packet handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,14 +136,14 @@
         <dependency>
             <groupId>com.palmergames.bukkit.towny</groupId>
             <artifactId>towny</artifactId>
-            <version>0.101.1.0</version>
+            <version>0.102.0.0</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.11.6</version>
+            <version>2.11.7</version>
             <scope>provided</scope>
         </dependency>
 
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>org.mcmonkey</groupId>
             <artifactId>sentinel</artifactId>
-            <version>2.9.0-SNAPSHOT</version>
+            <version>2.9.2-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>com.viaversion</groupId>
             <artifactId>viaversion-api</artifactId>
-            <version>5.2.1</version>
+            <version>5.5.1</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
This pull request refactors the yaw change packet logic in `ProtocolLibHandler.java` to also work with older versions.

* Refactored the `sendYawChange` method in `ProtocolLibHandler.java` to use a dedicated helper method (`setLookAtAnchor`) for setting the anchor in the LOOK_AT packet, improving code clarity and robustness.
* Added the `StructureModifier` import to support the new packet modification logic.
* Enhanced error handling and debug output in the yaw change logic, making troubleshooting easier and messages more informative.

Fixes #698

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `sendYawChange` to set LOOK_AT anchor via a new helper for broader version support, and updates several dependency versions.
> 
> - **Protocol handling**:
>   - Refactor `sendYawChange` in `src/main/java/me/zombie_striker/qg/handlers/ProtocolLibHandler.java` to use `setLookAtAnchor` for setting LOOK_AT anchor, improving cross-version compatibility.
>   - Add `StructureModifier` usage/import and enhance debug/error messages.
> - **Dependencies** (`pom.xml`):
>   - Bump `towny` to `0.102.0.0`.
>   - Bump `placeholderapi` to `2.11.7`.
>   - Bump `sentinel` to `2.9.2-SNAPSHOT`.
>   - Bump `viaversion-api` to `5.5.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ecceac9be91a873505d0584b95f2ef3b81fc2a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependency updates: Towny, placeholderapi, sentinel, and viaversion-api upgraded to latest versions.

* **Improvements**
  * Enhanced protocol packet processing with improved error handling and fallback mechanisms for better stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->