### PR TITLE
Fixed new version scheme support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>com.github.cryptomorin</groupId>
             <artifactId>XSeries</artifactId>
-            <version>13.6.0</version>
+            <version>13.8.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/me/zombie_striker/customitemmanager/pack/MultiVersionPackProvider.java
+++ b/src/main/java/me/zombie_striker/customitemmanager/pack/MultiVersionPackProvider.java
@@ -32,18 +32,19 @@ public class MultiVersionPackProvider implements ResourcepackProvider {
         if (player == null) return versions.get("0");
 
         String[] version = ViaVersionHook.getVersion(player).split("\\.");
-        int minor = Integer.parseInt(version[0]);
-        int patch = version.length > 1 ? Integer.parseInt(version[1]) : 0;
+        int major = Integer.parseInt(version[0]);
+        int minor = version.length > 1 ? Integer.parseInt(version[1]) : 0;
+        int patch = version.length > 2 ? Integer.parseInt(version[2]) : 0;
 
-        QAMain.DEBUG(player.getName() + " is using version " + minor + "." + patch);
+        QAMain.DEBUG(player.getName() + " is using version " + major + "." + minor + "." + patch);
 
-        String highest = findPack(minor, patch);
+        String highest = findPack(major, minor, patch);
 
         QAMain.DEBUG("Fond pack with version " + highest);
         return versions.get(highest);
     }
 
-    private @NotNull String findPack(int minor, int patch) {
+    private @NotNull String findPack(int major, int minor, int patch) {
         String highest = "0";
 
         for (String key : versions.keySet()) {
@@ -51,11 +52,21 @@ public class MultiVersionPackProvider implements ResourcepackProvider {
 
             String[] keyVersion = key.split("-");
 
-            int keyMinor = Integer.parseInt(keyVersion[0]);
-            int keyPatch = keyVersion.length > 1 ? Integer.parseInt(keyVersion[1]) : 0;
+            int keyMajor = Integer.parseInt(keyVersion[0]);
+            int keyMinor = keyVersion.length > 1 ? Integer.parseInt(keyVersion[1]) : 0;
+            int keyPatch = keyVersion.length > 2 ? Integer.parseInt(keyVersion[2]) : 0;
 
-            if (keyMinor < minor || (keyMinor == minor && keyPatch <= patch)) {
-                if (highest.equals("0") || keyMinor > Integer.parseInt(highest.split("-")[0])) {
+            if (
+                    keyMajor < major ||
+                            (keyMajor == major && keyMinor < minor) ||
+                            (keyMajor == major && keyMinor == minor && keyPatch <= patch)
+            ) {
+                if (
+                        highest.equals("0") ||
+                                keyMajor > Integer.parseInt(highest.split("\\.")[0]) ||
+                                (keyMajor == Integer.parseInt(highest.split("\\.")[0]) &&
+                                        keyMinor > Integer.parseInt(highest.split("\\.")[1]))
+                ) {
                     highest = key;
                 }
             }

--- a/src/main/java/me/zombie_striker/customitemmanager/pack/MultiVersionPackProvider.java
+++ b/src/main/java/me/zombie_striker/customitemmanager/pack/MultiVersionPackProvider.java
@@ -61,13 +61,19 @@ public class MultiVersionPackProvider implements ResourcepackProvider {
                             (keyMajor == major && keyMinor < minor) ||
                             (keyMajor == major && keyMinor == minor && keyPatch <= patch)
             ) {
-                if (
-                        highest.equals("0") ||
-                                keyMajor > Integer.parseInt(highest.split("\\.")[0]) ||
-                                (keyMajor == Integer.parseInt(highest.split("\\.")[0]) &&
-                                        keyMinor > Integer.parseInt(highest.split("\\.")[1]))
-                ) {
+                if (highest.equals("0")) {
                     highest = key;
+                } else {
+                    String[] highestVersion = highest.split("-");
+                    int highestMajor = Integer.parseInt(highestVersion[0]);
+                    int highestMinor = highestVersion.length > 1 ? Integer.parseInt(highestVersion[1]) : 0;
+                    int highestPatch = highestVersion.length > 2 ? Integer.parseInt(highestVersion[2]) : 0;
+
+                    if (keyMajor > highestMajor ||
+                            (keyMajor == highestMajor && keyMinor > highestMinor) ||
+                            (keyMajor == highestMajor && keyMinor == highestMinor && keyPatch > highestPatch)) {
+                        highest = key;
+                    }
                 }
             }
         }

--- a/src/main/java/me/zombie_striker/customitemmanager/qa/versions/V1_14/CustomGunItem.java
+++ b/src/main/java/me/zombie_striker/customitemmanager/qa/versions/V1_14/CustomGunItem.java
@@ -39,7 +39,7 @@ public class CustomGunItem extends AbstractCustomGunItem {
 	public CustomGunItem(){
 		Map<String, String> versions = new HashMap<>();
 		versions.put("0", "https://github.com/ZombieStriker/QualityArmory-Resourcepack/releases/download/latest/QualityArmory.zip");
-		versions.put("21-4", "https://github.com/ZombieStriker/QualityArmory-Resourcepack/releases/download/latest/QualityArmory-21.zip");
+		versions.put("1-21-4", "https://github.com/ZombieStriker/QualityArmory-Resourcepack/releases/download/latest/QualityArmory-21.zip");
 
 		CustomItemManager.setResourcepack(new MultiVersionPackProvider(versions));
 	}

--- a/src/main/java/me/zombie_striker/qg/QAMain.java
+++ b/src/main/java/me/zombie_striker/qg/QAMain.java
@@ -1072,13 +1072,14 @@ public class QAMain extends JavaPlugin {
                         }
 
                         // Migrate existing keys to support major version changes
-                        for (String key : packSection.getKeys(false)) {
+                        for (String key : new HashSet<>(packSection.getKeys(false))) {
                             try {
                                 String[] split = key.split("-");
                                 int first = Integer.parseInt(split[0]);
 
                                 if (first < 25 && first > 1) {
                                     packSection.set("1-" + key, packSection.getString(key));
+                                    packSection.set(key, null);
                                     saveTheConfig = true;
                                 }
                             } catch (NumberFormatException ignored) {}

--- a/src/main/java/me/zombie_striker/qg/QAMain.java
+++ b/src/main/java/me/zombie_striker/qg/QAMain.java
@@ -1064,13 +1064,14 @@ public class QAMain extends JavaPlugin {
                 else {
                     ConfigurationSection packSection = getConfig().getConfigurationSection("DefaultResourcepack");
                     if (packSection != null) {
-                        // Migrate
+                        // Migrate old 21 format because the default one on v2.0.18 was broken
                         if (packSection.contains("21")) {
                             packSection.set("21-4", packSection.getString("21"));
                             packSection.set("21", null);
                             saveTheConfig = true;
                         }
 
+                        // Migrate existing keys to support major version changes
                         for (String key : packSection.getKeys(false)) {
                             try {
                                 String[] split = key.split("-");

--- a/src/main/java/me/zombie_striker/qg/QAMain.java
+++ b/src/main/java/me/zombie_striker/qg/QAMain.java
@@ -279,7 +279,7 @@ public class QAMain extends JavaPlugin {
     }
 
     public static boolean isVersionHigherThan(int mainVersion, int secondVersion) {
-        return XReflection.supports(secondVersion);
+        return XReflection.supports(mainVersion, secondVersion, 0);
     }
 
     public static void toggleNightvision(Player player, Gun g, boolean add) {
@@ -1064,10 +1064,23 @@ public class QAMain extends JavaPlugin {
                 else {
                     ConfigurationSection packSection = getConfig().getConfigurationSection("DefaultResourcepack");
                     if (packSection != null) {
+                        // Migrate
                         if (packSection.contains("21")) {
                             packSection.set("21-4", packSection.getString("21"));
                             packSection.set("21", null);
                             saveTheConfig = true;
+                        }
+
+                        for (String key : packSection.getKeys(false)) {
+                            try {
+                                String[] split = key.split("-");
+                                int first = Integer.parseInt(split[0]);
+
+                                if (first < 25 && first > 1) {
+                                    packSection.set("1-" + key, packSection.getString(key));
+                                    saveTheConfig = true;
+                                }
+                            } catch (NumberFormatException ignored) {}
                         }
 
                         CustomItemManager.setResourcepack(new MultiVersionPackProvider(packSection));

--- a/src/main/java/me/zombie_striker/qg/handlers/AimManager.java
+++ b/src/main/java/me/zombie_striker/qg/handlers/AimManager.java
@@ -1,14 +1,8 @@
 package me.zombie_striker.qg.handlers;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
-import com.cryptomorin.xseries.reflection.XReflection;
 import me.zombie_striker.qg.QAMain;
 import me.zombie_striker.qg.api.QualityArmory;
 import me.zombie_striker.qg.guns.Gun;
-
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -17,6 +11,10 @@ import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 public class AimManager extends BukkitRunnable implements Listener {
 	private static final Map<UUID, Double> SWAYS = new HashMap<>();
@@ -43,7 +41,7 @@ public class AimManager extends BukkitRunnable implements Listener {
 				if (p.isSprinting() && g.isEnableSwayRunModifier()) {
 					sway *= QAMain.swayModifier_Run;
 				}
-				if (XReflection.supports(9) && !QualityArmory.isIronSights(p.getInventory().getItemInMainHand())) {
+				if (QAMain.isVersionHigherThan(1, 9) && !QualityArmory.isIronSights(p.getInventory().getItemInMainHand())) {
 					sway *= g.getSwayUnscopedMultiplier();
 				}
 			}

--- a/src/main/java/me/zombie_striker/qg/handlers/ParticleHandlers.java
+++ b/src/main/java/me/zombie_striker/qg/handlers/ParticleHandlers.java
@@ -17,7 +17,7 @@ public class ParticleHandlers {
 	public static boolean is13 = true;
 
 	public static void initValues() {
-		is13 = XReflection.supports(13);
+		is13 = QAMain.isVersionHigherThan(1, 13);
 	}
 
 	public static void spawnExplosion(Location loc) {

--- a/src/main/java/me/zombie_striker/qg/handlers/ProtocolLibHandler.java
+++ b/src/main/java/me/zombie_striker/qg/handlers/ProtocolLibHandler.java
@@ -129,7 +129,7 @@ public class ProtocolLibHandler {
                         }
 
                         // Handle different Minecraft versions
-                        if (XReflection.supports(16)) {
+                        if (QAMain.isVersionHigherThan(1, 16)) {
                             handleModern1_16PacketFormat(event, targetPlayer);
                         } else {
                             handleLegacyPacketFormat(event, targetPlayer, entityId);

--- a/src/main/java/me/zombie_striker/qg/hooks/ViaVersionHook.java
+++ b/src/main/java/me/zombie_striker/qg/hooks/ViaVersionHook.java
@@ -7,9 +7,10 @@ import me.zombie_striker.qg.QAMain;
 import org.bukkit.entity.Player;
 
 public final class ViaVersionHook {
+    private static final String SERVER_VERSION = XReflection.MAJOR_NUMBER + "." + XReflection.MINOR_NUMBER + "." + XReflection.PATCH_NUMBER;
 
     public static String getVersion(Player player) {
-        if (!QAMain.hasViaVersion) return XReflection.MINOR_NUMBER + "." + XReflection.PATCH_NUMBER;
+        if (!QAMain.hasViaVersion) return SERVER_VERSION;
 
         try {
             int version = Via.getAPI().getPlayerVersion(player.getUniqueId());
@@ -19,11 +20,11 @@ public final class ViaVersionHook {
                     .findFirst()
                     .map(pv -> {
                         String[] split = pv.getIncludedVersions().iterator().next().split("\\.");
-                        return split[1] + "." + (split.length > 2 ? split[2] : "0");
+                        return split[0] + "." + split[1] + "." + (split.length > 2 ? split[2] : "0");
                     })
-                .orElse(XReflection.MINOR_NUMBER + "." + XReflection.PATCH_NUMBER);
+                .orElse(SERVER_VERSION);
         } catch (Exception | Error e) {
-            return XReflection.MINOR_NUMBER + "." + XReflection.PATCH_NUMBER;
+            return SERVER_VERSION;
         }
     }
 }

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,3 +1,6 @@
+2.1.3
+  - Fixed 26.x support
+
 2.1.2
   - Added sound_equip_volume and sound_meleehit_volume fields
   - Added permissions for crafting and buying guns


### PR DESCRIPTION
Since Minecraft changed its version scheme, we need to update our checker to make sure we still support the legacy one but also the new one.

This change migrates all the old resourcepack config keys to include the major (defaults to 1) if the current one was below 25 which is a safe check as the last version with the old scheme was 1.21.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed support for version 26.x.

* **Improvements**
  * Improved version detection and pack selection to use three-part versioning.
  * Added migration to normalize legacy resource-pack keys and unified server-version fallback.
  * Replaced several reflection-based version checks with a central version utility.

* **Chores**
  * Updated XSeries dependency to 13.8.0.

* **Documentation**
  * Added 2.1.3 entry to changelog.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lorenzo0111/QualityArmory/pull/719)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->